### PR TITLE
make use of published juntagrico-custom-sub

### DIFF
--- a/juntagrico_assignment_export/__init__.py
+++ b/juntagrico_assignment_export/__init__.py
@@ -1,2 +1,2 @@
-name = 'juntagrico-assignment-export'
-version = '1.1.1'
+name = "juntagrico-assignment-export"
+version = "1.1.2rc1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-juntagrico-custom-sub @ git+http://github.com/juntagrico/juntagrico-custom-sub.git@main
+juntagrico-custom-sub>=0.0.3,<1.0.0


### PR DESCRIPTION
Juntagrico hat richtigerweise die Idee eingebrach juntagrico-custom-sub auf pypi zu stellen. 
Damit würde ich die Dependency dort referenzieren, was das Dependency Management etwas einfacher macht, da man nicht genau eine Version angeben muss. 